### PR TITLE
Fix iOS Safari zoom issue on search input focus

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,13 @@ export const metadata: Metadata = {
   title: 'First Watch Weather',
   description:
     "A React/NextJS Based Application that uses OpenWeather's web API to gather weather data and Geocodio's API to render weather conditions based on user's desired location",
+    viewport: {
+      width: 'device-width',
+      initialScale: 1,
+      maximumScale: 1,
+      userScalable: false,
+      viewportFit: 'cover',
+    },
 };
 
 const APILoaderWrapper = dynamic(

--- a/src/components/GooglePlacesPicker.tsx
+++ b/src/components/GooglePlacesPicker.tsx
@@ -11,8 +11,14 @@ export default memo(function GooglePlacesPicker({
     <div className="custom-place-picker">
       <PlacePicker
         className={clsx(
-          'w-full h-full border-gray-300 text-gray-700 bg-gray-100 custom-place-picker'
+          'w-full h-full border-gray-300 text-gray-700 bg-gray-100 custom-place-picker',
+          "text-base leading-normal", 
+
         )}
+        style={{
+          fontSize: '16px', //prevent autozoom on ios/safari devices
+          touchAction: 'manipulation'
+        }}
         placeholder="Enter a location name or address"
         onPlaceChange={handlePlaceChange}
       />


### PR DESCRIPTION
Issue reported from user that the browser window has trouble resizing after user clicks on searchbar.

it looks like this was caused by safari or ios devices autozooming to the element if the inner text is defined to be under 16px. I'll take this a note that my text is too small to read by default and increase the default size to be 16px. This includes the inner text set by Google Place's Searchbar component which seems to have a default size of 14px but inherits the font size via the 'container' wrapper